### PR TITLE
Fix a flaky test caused by getDeclaredMethods

### DIFF
--- a/webbeans-impl/src/main/java/org/apache/webbeans/container/BeanCacheKey.java
+++ b/webbeans-impl/src/main/java/org/apache/webbeans/container/BeanCacheKey.java
@@ -294,6 +294,8 @@ public final class BeanCacheKey
 
             Method[] member1 = type1.getDeclaredMethods();
             Method[] member2 = type2.getDeclaredMethods();
+            Arrays.sort(member1, MethodComparator.METHOD_COMPARATOR);
+            Arrays.sort(member2, MethodComparator.METHOD_COMPARATOR);
 
             // TBD: the order of the list of members seems to be deterministic
 
@@ -387,6 +389,15 @@ public final class BeanCacheKey
             }
         }
     }
+    private static class MethodComparator implements Comparator<Method> 
+    {
+        public static final MethodComparator METHOD_COMPARATOR = new MethodComparator();
+        @Override
+        public int compare(Method arg0, Method arg1) 
+        {
+            return arg0.getName().compareTo(arg1.getName());
+        }
+    } 
 
     private static final class LazyAnnotatedTypes
     {


### PR DESCRIPTION
 This flaky test is org.apache.webbeans.test.annotation.binding.BeanCacheKeyUnitTest#testEquals2Annotations in the module webbeans-impl. It is caused by getDeclaredMethods, according to [oracle's document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredMethods--):

> The elements in the returned array are not sorted and are not in any particular order.

Flaky tests are defined as tests that return both passes and failures despite no changes to the code or the test itself. This flaky test is detected by [NonDex](https://github.com/TestingResearchIllinois/NonDex). 
The flaky test is trying to test if the two BeanCacheKeys are equal. In BeanCacheKey's constructor, qualifiers will be sorted, which user AnnotationComparator. This comparator uses undeterminable getDeclareMethods, which causes the order of qualifiers to be not always the same. Therefore, I add sorting to the return elements of getDeclareMethods to fix this flaky test.